### PR TITLE
Docker-compose: make wordpress-cli depend on wordpress

### DIFF
--- a/srcs/cloud-1-iac/wordpress/docker-compose.yml
+++ b/srcs/cloud-1-iac/wordpress/docker-compose.yml
@@ -27,6 +27,8 @@ services:
   wordpress-cli:
     restart: on-failure
     image: wordpress:cli
+    depends_on:
+      - wordpress
     environment:
       WORDPRESS_DB_HOST: ${RDS_ENDPOINT}
       WORDPRESS_DB_USER: ${RDS_USERNAME}
@@ -34,7 +36,6 @@ services:
       WORDPRESS_DB_NAME: ${RDS_DB_NAME}
     command: >
       /bin/sh -c '
-      sleep 10;
       wp core install --path="/var/www/html" --url=${WP_URL} --title=${WP_TITLE} --admin_user=${WP_ADMIN_USER} --admin_password=${WP_ADMIN_PASSWORD} --admin_email=${WP_ADMIN_EMAIL}
       '
     volumes:


### PR DESCRIPTION
This in conjunction to `restart: on-failure` should allow for the arbitrary 10-second delay at startup (fix #9)

Resolves #8 